### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/acloudops/67beb722-5651-42a2-845e-9cf828b4fac4/ae79016a-fc28-4e35-9afc-5ec67bb40f92/_apis/work/boardbadge/0dbe0749-0bb7-47ae-829b-26897c7abd54)](https://dev.azure.com/acloudops/67beb722-5651-42a2-845e-9cf828b4fac4/_boards/board/t/ae79016a-fc28-4e35-9afc-5ec67bb40f92/Microsoft.RequirementCategory)
 
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#33](https://dev.azure.com/acloudops/67beb722-5651-42a2-845e-9cf828b4fac4/_workitems/edit/33). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.